### PR TITLE
CWS-938 fail the job when Mypy fails

### DIFF
--- a/.github/workflows/type_annotation.yml
+++ b/.github/workflows/type_annotation.yml
@@ -23,10 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: run Mypy
+        shell: bash
         env:
           CLOUDSMITH_PIP: ${{ secrets.CLOUDSMITH_PIP }}
         run: |
           set -x
+          set -o pipefail
           make deps
           if [ -f mypy_dirs.txt ]; then
             mypy @mypy_dirs.txt | tee mypy_report


### PR DESCRIPTION
Tee doesn't pass the exit code. `mypy . | tee mypy_report.txt`
`set -o pipefail` will enable the pipe command to fail when some of the command fail.
