### PR TITLE
CWS-938 cache installed dependency

### DIFF
--- a/.github/workflows/type_annotation.yml
+++ b/.github/workflows/type_annotation.yml
@@ -22,6 +22,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - uses: actions/cache@v2
+        id: cache-venv
+        with:
+          path: /root/venv/
+          key: venv-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('requirements/*.txt') }}
+      - run: python -m venv /root/venv/ && . /root/venv/bin/activate && make deps
+        if: steps.cache-venv.outputs.cache-hit != 'true'
       - name: run Mypy
         shell: bash
         env:
@@ -29,7 +36,7 @@ jobs:
         run: |
           set -x
           set -o pipefail
-          make deps
+          . /root/venv/bin/activate
           if [ -f mypy_dirs.txt ]; then
             mypy @mypy_dirs.txt | tee mypy_report
           else


### PR DESCRIPTION
Create a venv for installing dependencies and cache it to speed it up.
The first run creates the cache:
https://github.com/carta/automated-refactoring/runs/5221039631?check_suite_focus=true
The second run reuses the cache and saved ~20s.
https://github.com/carta/automated-refactoring/runs/5221074011?check_suite_focus=true