### PR TITLE
CWS-938 add a name and move env to venv step

### DIFF
--- a/.github/workflows/type_annotation.yml
+++ b/.github/workflows/type_annotation.yml
@@ -27,12 +27,13 @@ jobs:
         with:
           path: /root/venv/
           key: venv-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('requirements/*.txt') }}
-      - run: python -m venv /root/venv/ && . /root/venv/bin/activate && make deps
+      - name: Create a venv and install dependencies
+        run: python -m venv /root/venv/ && . /root/venv/bin/activate && pip install --upgrade pip setuptools wheel && make deps
         if: steps.cache-venv.outputs.cache-hit != 'true'
-      - name: run Mypy
-        shell: bash
         env:
           CLOUDSMITH_PIP: ${{ secrets.CLOUDSMITH_PIP }}
+      - name: run Mypy
+        shell: bash
         run: |
           set -x
           set -o pipefail


### PR DESCRIPTION
Improvement to venv creation step:
1. add a name
2. add missing env
3. install and upgrade: pip setuptools wheel