### PR TITLE
CWS-938 add optional setup_mypy config

### DIFF
--- a/.github/workflows/type_annotation.yml
+++ b/.github/workflows/type_annotation.yml
@@ -2,6 +2,11 @@ name: type_annotation
 
 on:
   workflow_call:
+    inputs:
+      setup_mypy:
+        default: 'echo "No extra setup."'
+        required: false
+        type: string
     secrets:
       DOCKERHUB_USERNAME:
         required: true
@@ -20,7 +25,7 @@ jobs:
         id: cache-venv
         with:
           path: ./venv/
-          key: venv-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('requirements/*.txt') }}-v0.1
+          key: venv-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('requirements/*.txt') }}-v0.1.0
       - name: Create a venv and install dependencies
         run: |
           set -x
@@ -37,6 +42,7 @@ jobs:
           set -x
           set -o pipefail
           . ./venv/bin/activate
+          ${{ inputs.setup_mypy }}
           if [ -f mypy_dirs.txt ]; then
             mypy @mypy_dirs.txt | tee mypy_report.txt
           else


### PR DESCRIPTION
Allow the client codebase to do extra setup before running Mypy.
Verified with 
https://github.com/carta/compensation-service/runs/5278064788
and 
https://github.com/carta/automated-refactoring/runs/5278094072