### PR TITLE
CWS-938 use dependent jobs

### DIFF
--- a/.github/workflows/type_annotation.yml
+++ b/.github/workflows/type_annotation.yml
@@ -17,31 +17,65 @@ on:
       CARTA_CI_GITHUB_TOKEN:
         required: true
 jobs:
-  run_mypy:
+  checkout:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+        with:
+          path: src
+      - uses: actions/cache@v2
+        id: cache-checkout
+        with:
+          path: ./src/
+          key: checkout-${{ github.sha }}-v0.1.0
+
+  install_dependency:
+    runs-on: ubuntu-latest
+    needs: checkout
+    steps:
+      - uses: actions/cache@v2
+        id: cache-checkout
+        with:
+          path: ./src/
+          key: checkout-${{ github.sha }}-v0.1.0
       - uses: actions/cache@v2
         id: cache-venv
         with:
           path: ./venv/
-          key: venv-${{ hashFiles('**/requirements*.txt') }}-${{ hashFiles('requirements/*.txt') }}-v0.1.0
+          key: venv-${{ hashFiles('src/**/requirements*.txt') }}-${{ hashFiles('src/requirements/*.txt') }}-v0.1.0
       - name: Create a venv and install dependencies
+        working-directory: src
         run: |
           set -x
-          python -m venv ./venv/
-          . ./venv/bin/activate
+          python -m venv ../venv/
+          . ../venv/bin/activate
           pip install --upgrade pip wheel
           pip install setuptools==58.0.1 && make deps
         if: steps.cache-venv.outputs.cache-hit != 'true'
         env:
           CLOUDSMITH_PIP: ${{ secrets.CLOUDSMITH_PIP }}
+
+  run_mypy:
+    runs-on: ubuntu-latest
+    needs: install_dependency
+    steps:
+      - uses: actions/cache@v2
+        id: cache-checkout
+        with:
+          path: ./src/
+          key: checkout-${{ github.sha }}-v0.1.0
+      - uses: actions/cache@v2
+        id: cache-venv
+        with:
+          path: ./venv/
+          key: venv-${{ hashFiles('src/**/requirements*.txt') }}-${{ hashFiles('src/requirements/*.txt') }}-v0.1.0
       - name: run Mypy
         shell: bash
+        working-directory: src
         run: |
           set -x
           set -o pipefail
-          . ./venv/bin/activate
+          . ../venv/bin/activate
           ${{ inputs.setup_mypy }}
           curl -LJO https://raw.githubusercontent.com/carta/.github/main/configs/mypy.ini
           if [ -f mypy_dirs.txt ]; then
@@ -51,11 +85,12 @@ jobs:
           fi
       - name: report Mypy errors on the PR
         if: ${{ failure() }}
+        working-directory: src
         env:
           CLOUDSMITH_PIP: ${{ secrets.CLOUDSMITH_PIP }}
           GITHUB_TOKEN: ${{ secrets.CARTA_CI_GITHUB_TOKEN }}
         run: |
           set -x
-          . ./venv/bin/activate
+          . ../venv/bin/activate
           pip install --upgrade fixit-linter --extra-index-url=https://dl.cloudsmith.io/${CLOUDSMITH_PIP}/carta/pip/python/index/
           python -m fixit_linter.linter.ci.add_comment_on_pr --message "Mypy identified some errors:" --inline --from-file mypy_report.txt --parser mypy

--- a/.github/workflows/type_annotation.yml
+++ b/.github/workflows/type_annotation.yml
@@ -39,10 +39,20 @@ jobs:
           path: ./src/
           key: checkout-${{ github.sha }}-v0.1.0
       - uses: actions/cache@v2
+        id: cache-pip-http
+        with:
+          path: /home/runner/.cache/pip/http
+          key: pip-http-v0.1.0
+      - uses: actions/cache@v2
+        id: cache-pip-wheel
+        with:
+          path: /home/runner/.cache/pip/wheels
+          key: pip-wheel-v0.1.0
+      - uses: actions/cache@v2
         id: cache-venv
         with:
           path: ./venv/
-          key: venv-${{ hashFiles('src/**/requirements*.txt') }}-${{ hashFiles('src/requirements/*.txt') }}-v0.1.0
+          key: venv-${{ hashFiles('src/**/requirements*.txt') }}-${{ hashFiles('src/requirements/*.txt') }}-v0.1.4
       - name: Create a venv and install dependencies
         working-directory: src
         run: |
@@ -51,6 +61,7 @@ jobs:
           . ../venv/bin/activate
           pip install --upgrade pip wheel
           pip install setuptools==58.0.1 && make deps
+          pip cache info
         if: steps.cache-venv.outputs.cache-hit != 'true'
         env:
           CLOUDSMITH_PIP: ${{ secrets.CLOUDSMITH_PIP }}
@@ -68,7 +79,7 @@ jobs:
         id: cache-venv
         with:
           path: ./venv/
-          key: venv-${{ hashFiles('src/**/requirements*.txt') }}-${{ hashFiles('src/requirements/*.txt') }}-v0.1.0
+          key: venv-${{ hashFiles('src/**/requirements*.txt') }}-${{ hashFiles('src/requirements/*.txt') }}-v0.1.4
       - name: run Mypy
         shell: bash
         working-directory: src


### PR DESCRIPTION
Break down checkout and install_dependency as separate jobs.
So we can use cache more effectively.
It also allows future workflows to reuse just checkout when they don't need installed dependency.

Tested with
https://github.com/carta/automated-refactoring/pull/215/files
By caching pip http and wheel files, the deps installation time was improved from 30s
https://github.com/carta/automated-refactoring/runs/5324378354
to 22s
https://github.com/carta/automated-refactoring/runs/5324401804

Tested with
https://github.com/carta/carta-web/pull/73970
The PR comments work as expected.
By caching pip http and wheel files, the deps installation time was improved from 15m 13s
https://github.com/carta/carta-web/runs/5323855727
to 7m 47s
https://github.com/carta/carta-web/runs/5324694555