### PR TITLE
CWS-946 use head_ref when it's run by pull request

### DIFF
--- a/.github/workflows/type_annotation.yml
+++ b/.github/workflows/type_annotation.yml
@@ -27,16 +27,15 @@ jobs:
       - uses: actions/checkout@master
         with:
           path: src
+          ref: ${{ github.head_ref }}
+          fetch-depth: 50
+        if: github.event_name == 'pull_request'
+      - uses: actions/checkout@master
+        with:
+          path: src
           ref: ${{ github.ref_name }}
-      - name: configure Git
-        shell: bash
-        working-directory: src
-        run: |
-          git config pull.rebase true
-          git config user.name 'carta-ci'
-          git config user.email 'carta-ci@carta.com'
-          git fetch origin ${{ github.ref_name }} --shallow-since=2022-03-30
-          git reset --hard origin/${{ github.ref_name }}
+          fetch-depth: 50
+        if: github.event_name != 'pull_request'
       - uses: actions/cache@v2
         id: cache-checkout
         with:


### PR DESCRIPTION
ref_name is not a branch name when it's run by pull_request event.
That causes failure https://github.com/carta/automated-refactoring/actions/runs/2091601579
This change use head_ref when it's a pull_request
https://docs.github.com/en/actions/learn-github-actions/contexts
and use ref_name when it's not.

Tested in
- https://github.com/carta/automated-refactoring/runs/5821638869
- https://github.com/carta/carta-web/runs/5821713817