### PR TITLE
CWS-1101 skip install_dependency if use_python is false

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -56,6 +56,7 @@ jobs:
   install_dependency:
     runs-on: ubuntu-latest
     needs: checkout
+    if: ${{ inputs.for_python }}
     steps:
       - uses: actions/cache@v2
         id: cache-checkout


### PR DESCRIPTION
Skip unnecessary install_dependency job when use_python is false.
Tested in https://github.com/carta/automated-refactoring/pull/323