### PR TITLE
CWS-1099 add CLOUDSMITH_PIP_TEST env variable to make deps step

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -90,6 +90,7 @@ jobs:
         if: steps.cache-venv.outputs.cache-hit != 'true'
         env:
           CLOUDSMITH_PIP: ${{ secrets.CLOUDSMITH_PIP }}
+          CLOUDSMITH_PIP_TEST: ${{ secrets.CLOUDSMITH_PIP_TEST }}
 
   run_mypy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
CLOUDSMITH_PIP_TEST env variable is needed for integrating testing test packages.