### PR TITLE
[CWS-1132] Create log path for Mypy Linter

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -132,7 +132,8 @@ jobs:
           ${{ inputs.setup_mypy }}
           curl -LJO https://raw.githubusercontent.com/carta/.github/main/configs/mypy.ini
           echo "${{ inputs.extra_mypy_config }}" >> mypy.ini
-          
+
+          mkdir -p logs/
           python -m fixit_linter.linter.general.mypy_linter
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`log` path creation was wrongly removed [here](https://github.com/carta/.github/pull/40).

This re-add the log path creation for every run