### PR TITLE
CWS-1162 Fix LibCST parsing error on Python 3.10

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -156,6 +156,7 @@ jobs:
           S3_KEY: ${{ secrets.AUTOMATED_REFACTORING_S3_ACCESS_KEY }}
           S3_SECRET: ${{ secrets.AUTOMATED_REFACTORING_S3_ACCESS_SECRET }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
+          LIBCST_PARSER_TYPE: native
         run: |
           set -x
           if [ -z "${{ inputs.fixit_linter_test_version }}" ]


### PR DESCRIPTION
LIBCST_PARSER_TYPE=native enables LibCST to parse 3.10 code.
https://github.com/Instagram/LibCST/releases/tag/v0.4.0