### PR TITLE
[DTA-3653] Install pip-tools in mypy linter

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -99,6 +99,7 @@ jobs:
           python -m venv ../venv/
           . ../venv/bin/activate
           pip install --upgrade pip wheel
+          pip install pip-tools
           pip install setuptools==58.0.1 && make deps
           pip cache info
           if [ -z "${{ inputs.fixit_linter_test_version }}" ]
@@ -128,7 +129,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
-          
+
   run_fixit_linters:
     runs-on: ubuntu-latest
     needs: [checkout, prepare_fixit_venv]


### PR DESCRIPTION
### Problem

`mypy` linter is failing in the ds-airflow repo. `pip-tools` is missing. https://github.com/carta/ds-airflow/runs/6882229837?check_suite_focus=true

```
Successfully installed setuptools-58.0.1
[62](https://github.com/carta/ds-airflow/runs/6882229837?check_suite_focus=true#step:6:63)
+ make deps
[63](https://github.com/carta/ds-airflow/runs/6882229837?check_suite_focus=true#step:6:64)
make: pip-sync: Command not found
[64](https://github.com/carta/ds-airflow/runs/6882229837?check_suite_focus=true#step:6:65)
make: *** [Makefile:38: install] Error 127
[65](https://github.com/carta/ds-airflow/runs/6882229837?check_suite_focus=true#step:6:66)
Error: Process completed with exit code 2.
```

### Solution

Install `pip-tools`