### PR TITLE
[CWS-1016] Add GH CI Token to run custom commands

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -127,6 +127,7 @@ jobs:
           mkdir -p logs/
           python -m fixit_linter.linter.general.mypy_linter
         env:
+          GITHUB_TOKEN_CI: ${{ secrets.CARTA_CI_GITHUB_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DD_API_KEY: ${{ secrets.DD_API_KEY }}
 


### PR DESCRIPTION
Some custom commands executed from reusable workflows needs the private GH Token to be executed.