### PR TITLE
Adding YAML validator

### DIFF
--- a/.github/actions/prepare_fixit_venv.yml
+++ b/.github/actions/prepare_fixit_venv.yml
@@ -33,10 +33,10 @@ runs:
         latest_version = search("from versions: (?P<versions>[^)]+)\)", stderr).group("versions").split(", ")[-1]
         print(f"::set-output name=latest_version::{latest_version}")
     - uses: actions/cache@v2
-        id: cache-fixit-venv
-        with:
-          path: ./fixit-venv/
-          key: fixit-venv-${{ steps.latest_version.outputs.latest_version }}-${{ inputs.FIXIT_LINTER_VERSION }}-v0.1.0
+      id: cache-fixit-venv
+      with:
+        path: ./fixit-venv/
+        key: fixit-venv-${{ steps.latest_version.outputs.latest_version }}-${{ inputs.FIXIT_LINTER_VERSION }}-v0.1.0
     - name: Create a venv and install fixit-linter
       shell: bash
       run: |

--- a/.github/actions/prepare_fixit_venv.yml
+++ b/.github/actions/prepare_fixit_venv.yml
@@ -33,10 +33,10 @@ runs:
         latest_version = search("from versions: (?P<versions>[^)]+)\)", stderr).group("versions").split(", ")[-1]
         print(f"::set-output name=latest_version::{latest_version}")
     - uses: actions/cache@v2
-      id: cache-fixit-venv
-      with:
-        path: ./fixit-venv/
-        key: fixit-venv-${{ steps.latest_version.outputs.latest_version }}-${{ inputs.FIXIT_LINTER_VERSION }}-v0.1.0
+        id: cache-fixit-venv
+        with:
+          path: ./fixit-venv/
+          key: fixit-venv-${{ steps.latest_version.outputs.latest_version }}-${{ inputs.FIXIT_LINTER_VERSION }}-v0.1.0
     - name: Create a venv and install fixit-linter
       shell: bash
       run: |

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -1,4 +1,4 @@
-name: validate-xaml
+name: validate-yml
 
 on:
   - push

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -1,7 +1,11 @@
 name: validate-yml
 
 on:
-  - push
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches:
+      - main
 
 jobs:
   validate-yaml:

--- a/.github/workflows/validator.yml
+++ b/.github/workflows/validator.yml
@@ -1,0 +1,12 @@
+name: validate-xaml
+
+on:
+  - push
+
+jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Validate repository
+        run: yamllint .

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,15 @@
+extends: default
+
+rules:
+  line-length:
+    max: 200
+    level: warning
+  # Ref: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.document_start
+  document-start:
+    present: false
+  # Ref: https://yamllint.readthedocs.io/en/stable/rules.html#module-yamllint.rules.truthy
+  # Also required to manage a false positive with github configuration:
+  # https://github.com/adrienverge/yamllint/issues/158
+  truthy:
+    allowed-values: ['true', 'false']
+    check-keys: false


### PR DESCRIPTION
Parse errors on YAML files used by GitHub Actions are only captured during runtime. 

This workflow can analyze all `.yml` files in this codebase using the [yamllint library](https://yamllint.readthedocs.io/en/stable/index.html) to capture structural errors early in tests.

Result tests: https://github.com/carta/.github/actions/runs/2674038686
<img width="560" alt="image" src="https://user-images.githubusercontent.com/38961450/179126147-c47232f6-d2ea-41a2-85e9-19dde95daa48.png">
