### PR TITLE
Fix pep8 not found for flake8 run in carta-web

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -175,7 +175,7 @@ jobs:
           set -o pipefail
           . ../fixit-venv/bin/activate
           
-          export PYTHONPATH="$(pwd)/"
+          export PYTHONPATH=`pwd`
           
           if [ ! -f ".flake8" ]; then
             curl -LJO https://raw.githubusercontent.com/carta/.github/main/configs/.flake8

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -175,6 +175,8 @@ jobs:
           set -o pipefail
           . ../fixit-venv/bin/activate
           
+          export PYTHONPATH="$(pwd)/"
+          
           if [ ! -f ".flake8" ]; then
             curl -LJO https://raw.githubusercontent.com/carta/.github/main/configs/.flake8
           fi 


### PR DESCRIPTION
Some codebases use custom validations that uses local modules. This change fix the import problem that was happening on `carta-web`.

Tested here: https://github.com/carta/carta-web/actions/runs/2707389168