### PR TITLE
CW-338 download fixit-requirements.txt in the beginning

### DIFF
--- a/.github/actions/prepare_fixit_venv.yml
+++ b/.github/actions/prepare_fixit_venv.yml
@@ -15,10 +15,20 @@ outputs:
     value: ${{ steps.latest_version.outputs.latest_version }}
   python-path:
     value: ${{ steps.python-version-setup.outputs.python-path }}
+  fixit_venv_hash:
+    value: ${{ steps.fixit_venv_hash.outputs.fixit_venv_hash }}
 
 runs:
   using: 'composite'
   steps:
+    - name: download fixit-requirements.txt
+      id: fixit_venv_hash
+      shell: bash
+      run: |
+        set -x
+        curl -LJO https://raw.githubusercontent.com/carta/.github/main/fixit-requirements.txt
+        md5=($(md5sum fixit-requirements.txt))  # the outer parentheses removes the file name
+        echo "::set-output name=fixit_venv_hash::$md5"
     - name: find the latest version
       id: latest_version
       shell: python
@@ -44,7 +54,7 @@ runs:
       id: cache-fixit-venv
       with:
         path: ./fixit-venv/
-        key: fixit-venv-${{ inputs.PYTHON_VERSION }}-${{ hashFiles('fixit-requirements.txt') }}-${{ steps.latest_version.outputs.latest_version }}-${{ inputs.FIXIT_LINTER_VERSION }}-v0.1.0
+        key: fixit-venv-${{ inputs.PYTHON_VERSION }}-${{ steps.fixit_venv_hash.outputs.fixit_venv_hash }}-${{ steps.latest_version.outputs.latest_version }}-${{ inputs.FIXIT_LINTER_VERSION }}-v0.1.0
     - name: Create a venv and install fixit-linter
       shell: bash
       run: |
@@ -59,8 +69,5 @@ runs:
         else
           pip install --upgrade fixit-linter${{ inputs.FIXIT_LINTER_VERSION }} --extra-index-url=https://dl.cloudsmith.io/${{ inputs.CLOUDSMITH_PIP_TEST }}/carta/pip-test/python/index/
         fi
-        
-        curl -LJO https://raw.githubusercontent.com/carta/.github/main/fixit-requirements.txt
-        
         pip install -r fixit-requirements.txt
       if: steps.cache-fixit-venv.outputs.cache-hit != 'true'

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -57,11 +57,12 @@ jobs:
     outputs:
       latest_version: ${{ steps.prepare_fixit_venv.outputs.latest_version }}
       python_path: ${{ steps.prepare_fixit_venv.outputs.python-path }}
+      fixit_venv_hash: ${{ steps.prepare_fixit_venv.outputs.fixit_venv_hash }}
     steps:
       - name: Download action file
         run: |
           mkdir prepare_fixit_venv && cd prepare_fixit_venv
-          curl -LJ -o action.yml https://raw.githubusercontent.com/carta/.github/main/.github/actions/prepare_fixit_venv.yml
+          curl -LJ -o action.yml https://raw.githubusercontent.com/carta/.github/CW-338/.github/actions/prepare_fixit_venv.yml
       - name: Run prepare_fix_venv
         id: prepare_fixit_venv
         uses: ./prepare_fixit_venv
@@ -85,7 +86,7 @@ jobs:
         id: cache-fixit-venv
         with:
           path: ./fixit-venv/
-          key: fixit-venv-${{ inputs.python_version }}-${{ hashFiles('fixit-requirements.txt') }}-${{ needs.prepare_fixit_venv.outputs.latest_version }}-${{ inputs.fixit_linter_test_version }}-v0.1.0
+          key: fixit-venv-${{ inputs.python_version }}-${{ needs.prepare_fixit_venv.outputs.fixit_venv_hash }}-${{ needs.prepare_fixit_venv.outputs.latest_version }}-${{ inputs.fixit_linter_test_version }}-v0.1.0
       - uses: actions/cache@v2
         id: cache-venv
         with:
@@ -154,7 +155,7 @@ jobs:
         id: cache-fixit-venv
         with:
           path: ./fixit-venv/
-          key: fixit-venv-${{ inputs.python_version }}-${{ hashFiles('fixit-requirements.txt') }}-${{ needs.prepare_fixit_venv.outputs.latest_version }}-${{ inputs.fixit_linter_test_version }}-v0.1.0
+          key: fixit-venv-${{ inputs.python_version }}-${{ needs.prepare_fixit_venv.outputs.fixit_venv_hash }}-${{ needs.prepare_fixit_venv.outputs.latest_version }}-${{ inputs.fixit_linter_test_version }}-v0.1.0
       - uses: actions/cache@v2
         id: cache-pip-http
         with:
@@ -201,7 +202,7 @@ jobs:
         id: cache-fixit-venv
         with:
           path: ./fixit-venv/
-          key: fixit-venv-${{ inputs.python_version }}-${{ hashFiles('fixit-requirements.txt') }}-${{ needs.prepare_fixit_venv.outputs.latest_version }}-${{ inputs.fixit_linter_test_version }}-v0.1.0
+          key: fixit-venv-${{ inputs.python_version }}-${{ needs.prepare_fixit_venv.outputs.fixit_venv_hash }}-${{ needs.prepare_fixit_venv.outputs.latest_version }}-${{ inputs.fixit_linter_test_version }}-v0.1.0
       - name: run pull_request linter
         working-directory: src
         shell: bash

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -62,7 +62,7 @@ jobs:
       - name: Download action file
         run: |
           mkdir prepare_fixit_venv && cd prepare_fixit_venv
-          curl -LJ -o action.yml https://raw.githubusercontent.com/carta/.github/CW-338/.github/actions/prepare_fixit_venv.yml
+          curl -LJ -o action.yml https://raw.githubusercontent.com/carta/.github/main/.github/actions/prepare_fixit_venv.yml
       - name: Run prepare_fix_venv
         id: prepare_fixit_venv
         uses: ./prepare_fixit_venv


### PR DESCRIPTION
Tested in https://github.com/carta/automated-refactoring/runs/7456608316?check_suite_focus=true
fixit-venv-3.8-e331759beb509154809cdd3e67835074-0.0.193--v0.1.0 is used as the cache key in prepare_fixit_venv job, run_mypy, run_flake8 and run_fixit_linters jobs.